### PR TITLE
integrate parti update: fix iso9660 detection issues with latest libblkid (bsc#1274273)

### DIFF
--- a/tools/parti/NOTE
+++ b/tools/parti/NOTE
@@ -1,4 +1,4 @@
-parti 2.12
+parti 2.13
 
 Does not contain libmediacheck related parts (__WITH_MEDIA_CHECK__ is
 undefined) to avoid additional linking dependency (and the info is not used

--- a/tools/parti/filesystem.c
+++ b/tools/parti/filesystem.c
@@ -23,6 +23,9 @@
 #include "filesystem.h"
 #include "util.h"
 
+// read (and cache) this much of each file system for probing
+#define FS_READ_BYTES	(256 * 1024)
+
 typedef struct {
   char *type;
   char *label;
@@ -54,7 +57,7 @@ int fs_probe(fs_detail_t *fs, disk_t *disk, uint64_t offset)
 
   uint8_t buf[disk->block_size];
 
-  for(uint64_t u = 0; u < 68 * 1024; u += disk->block_size) {
+  for(uint64_t u = 0; u < FS_READ_BYTES; u += disk->block_size) {
     disk_read(disk, buf, (offset + u) / disk->block_size, 1);
   }
 


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1274273

`libblkid` now expects a larger chunk of file system data.

Notably iso9660 detection will fail otherwise.

## See also

This follows the fix in parti

- https://github.com/wfeldt/parti/pull/26